### PR TITLE
feat: add option to define the file overwriting strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # FetchPool Changelog
 
+## 1.0.1
+
+- Add `fileOverwritingStrategy` option of either `overwrite` (default) or `skip`. This enables a basic way to deal with the case that the destination file already exists on disk. The `FetchPoolResult` class has a new corresponding `persistenceResult` property of either `saved`, `overwritten`, or `skipped`.
 ## 1.0.0
 
 - Initial version.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A library to easily and asynchronously download a list of URLs in parallel, usin
 maximum number of concurrent connections. This lets you download a list of hundreds of files,
 while only ever downloading a few at the same time.
 
-![Tests](https://github.com/thesmythgroup/fetch_pool/actions/workflows/dart.yml/badge.svg)
+[![Pub](https://img.shields.io/pub/v/fetch_pool.svg)](https://pub.dartlang.org/packages/fetch_pool)
+[![Tests](https://github.com/thesmythgroup/fetch_pool/actions/workflows/dart.yml/badge.svg)](https://github.com/thesmythgroup/fetch_pool/actions/workflows/dart.yml)
 
 ## Usage
 
@@ -47,6 +48,8 @@ By default, the downloaded files will be named using the `FetchPoolFileNamingStr
 That means that a URL like `https://test.com/img.png?a=123&b=456` will result in a local filename of `img.png`.
 Using `basenameWithQueryParams` would result in `img_a_123_b_456.png`.
 Using `base64EncodedUrl` base64 encodes the whole URL and would result in a local filename of `aHR0cHM6Ly90ZXN0LmNvbS9pbWcucG5nP2E9MTIzJmI9NDU2`.
+
+By default, the `FetchPoolFileOverwritingStrategy.overwrite` strategy is used. That means that any existing files of the same name in the `destinationDirectory` will be overwritten. Using the `FetchPoolFileOverwritingStrategy.skip` strategy will skip existing files and not even attempt to download them. The `FetchPoolResult` object for each requested URL has a `persistenceResult` property that indicates if/how the file was persisted (`saved`, `overwritten`, or `skipped`).
 
 ## Credits
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fetch_pool
 description: A library to asynchronously download URLs using a pool of parallel connections.
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/thesmythgroup/fetch_pool
 
 environment:


### PR DESCRIPTION
Add `fileOverwritingStrategy` option of either `overwrite` (default) or `skip`. This enables a basic way to deal with the case that the destination file already exists on disk. The `FetchPoolResult` class has a new corresponding `persistenceResult` property of either `saved`, `overwritten`, or `skipped`.

## Checklist

Please ensure your pull request fulfills the following requirements:

- [X] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md))
- [X] Tests for any changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## Type

What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->

```
[ ] Bug fix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other (please describe below)
```

## Breaking Changes

Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->

```
[ ] Yes
[X] No
```

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information

<!-- please include any additional information that might be helpful during review -->

n/a
